### PR TITLE
Update Winget Releaser workflow

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -54,8 +54,7 @@ jobs:
         with:
           files: .\target\release\PowerSession.exe
       - name: Publish to WinGet
-        uses: vedantmgoyal2009/winget-releaser@latest
+        uses: vedantmgoyal2009/winget-releaser@v1
         with:
           identifier: Watfaq.PowerSession
-          release-tag: ${{ github.ref }}
           token: ${{ secrets.WINGET_TOKEN }}


### PR DESCRIPTION
Winget Releaser now uses versioned tags instead of `latest`, and now uses `github.ref_name` as a fallback value for `release-tag` by default.

As mentioned in https://github.com/Watfaq/PowerSession-rs/pull/53#issuecomment-1260246827, please install the [Pull](https://github.com/apps/pull) app on the winget-pkgs fork to ensure that it is always updated.